### PR TITLE
fix typo in interface name

### DIFF
--- a/hooks/nova_compute_hooks.py
+++ b/hooks/nova_compute_hooks.py
@@ -275,7 +275,7 @@ def pgsql_db_joined():
         raise Exception(e)
 
     relation_set(**{'database': config('database'),
-                    'private-address': get_relation_ip('psql-db')})
+                    'private-address': get_relation_ip('pgsql-db')})
 
 
 @hooks.hook('shared-db-relation-changed')


### PR DESCRIPTION
The 'pgsql-db' interface was referenced incorrectly per typo in the `pgsql-relation-joined` hook.
This pr fixes the typo. 

Fixes: 1736217